### PR TITLE
Fix/container travis

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,4 +6,4 @@ travisbuildchildren.sh
 ^cran-comments\.md$
 ^_pkgdown\.yml$
 ^docs$
-travis-tool.sh
+^build-cmtk.sh$

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ before_install:
 
 before_script:
   - export PATH=$PATH:$HOME/usr/local/bin
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start
 
 after_success:
   - Rscript -e 'library(covr);coveralls(exlusions="R/zzz.R")'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,26 @@
-language: c
-script: ./travis-tool.sh run_tests
-before_install:
-  - curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
-  - chmod 755 ./travis-tool.sh
-  - ./travis-tool.sh bootstrap
-  - ./travis-tool.sh r_binary_install rgl RANN igraph filehash digest testthat yaml XML RcppEigen RCurl stringi stringr
-  - bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
-  - sudo apt-get install cmtk --no-install-recommends
-install:
-  - ./travis-tool.sh github_package jimhester/covr
-  - ./travis-tool.sh install_deps
-  - sh -e /etc/init.d/xvfb start
-notifications:
-  email:
-    on_success: change
-    on_failure: change
+# R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
+
+language: R
+sudo: false
+cache:
+  packages: true
+  directories:
+  - $HOME/usr/local
+
+r_github_packages:
+  - jimhester/covr
+
 env:
   global:
     - secure: U5L4JHPa5/mpcDjL60XZVDXtT/nQe4lyhCG6pIj7dF8N6iLRO/vh0ChPxZsBhunKaNMnu59MEqn9nvp09kodV7DzW1nNV+UVi2ZtXpAFejHOK6T4d31vGShCnoM5BkTeMp7exX8yfKWw3Zw0JY47sHTLFihYbwUFqsus0aqT0hIK
-    - WARNINGS_ARE_ERRORS=1
-    - _R_CHECK_FORCE_SUGGESTS_=0
     - DISPLAY=:99.0
+    
+before_install:
+  - bash build-cmtk.sh
+
+before_script:
+  - export PATH=$PATH:$HOME/usr/local/bin
+
 after_success:
   - Rscript -e 'library(covr);coveralls(exlusions="R/zzz.R")'
   - chmod 755 ./travisbuildchildren.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ r_github_packages:
 env:
   global:
     - secure: U5L4JHPa5/mpcDjL60XZVDXtT/nQe4lyhCG6pIj7dF8N6iLRO/vh0ChPxZsBhunKaNMnu59MEqn9nvp09kodV7DzW1nNV+UVi2ZtXpAFejHOK6T4d31vGShCnoM5BkTeMp7exX8yfKWw3Zw0JY47sHTLFihYbwUFqsus0aqT0hIK
-    - DISPLAY=:99.0
     
 before_install:
   - bash build-cmtk.sh
@@ -27,6 +26,4 @@ before_script:
 after_success:
   - Rscript -e 'devtools::install();nat::cmtk.mat2dof(version=TRUE)'
   - Rscript -e 'library(covr);coveralls(exlusions="R/zzz.R")'
-  - chmod 755 ./travisbuildchildren.sh
-  - ./travisbuildchildren.sh
-  
+  - bash travisbuildchildren.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,10 @@ before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
   - sleep 3 # give xvfb some time to start
-
+  
 after_success:
+  - Rscript -e 'devtools::install();nat::cmtk.mat2dof(version=TRUE)'
   - Rscript -e 'library(covr);coveralls(exlusions="R/zzz.R")'
   - chmod 755 ./travisbuildchildren.sh
   - ./travisbuildchildren.sh
+  

--- a/build-cmtk.sh
+++ b/build-cmtk.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+# check to see if cmtk install folder is empty
+if [ ! -d "$HOME/usr/local/bin" ]; then
+  git clone --depth 50 https://github.com/jefferis/cmtk
+  cd cmtk/core && mkdir build && cd build && cmake .. && make DESTDIR=$HOME/ all install
+else
+  echo 'Using cached $HOME/usr/local directory.';
+fi


### PR DESCRIPTION
This switches to the modern containerised travis for faster builds. Old style builds are now deprecated. This was achieved by compiling CMTK from source rather than trying to install from neurodebian (which was never added to the travis whitelist).